### PR TITLE
Feat/proxy firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 
 # next.js build output
 .next
+
+.idea

--- a/README.md
+++ b/README.md
@@ -38,15 +38,13 @@ Usage
 
 Options
   --path         Path to migration files  (default ./migrations)
-  --projectId    Target firebase project
-  --dryrun       Simulates changes
+  --dryRun       Simulates changes
   -h, --help     Displays this message
 
 Examples
   $ fireway migrate
   $ fireway migrate --path=./my-migrations
-  $ fireway migrate --projectId=my-staging-id
-  $ fireway migrate --dryrun
+  $ fireway migrate --dryRun
 ```
 
 ## Migration file format
@@ -63,7 +61,7 @@ module.exports.migrate = async ({firestore, FieldValue}) => {
 
 ## Running Locally
 
-Typically, `fireway` expects a `--projectId` option that lets you specify the Firebase project associated with your Firestore instance against which it performs migrations. 
+Typically, `fireway` expects an `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set.
 However, most likely you'll want to test your migration scripts _locally_ first before running them against your actual (presumably, production) instances. 
 If you are using the [Firestore emulator](https://firebase.google.com/docs/emulator-suite/connect_firestore), define the FIRESTORE_EMULATOR_HOST environment variable, e.g.:
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     }
   },
   "dependencies": {
-    "@google-cloud/firestore": "^4.2.0",
     "firebase-admin": "^9.2.0",
     "md5": "^2.2.1",
     "sade": "^1.6.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,7 @@ prog
     .example('migrate --dryrun')
     .action(async (opts) => {
         try {
+            // TODO: provide app instance here in ops, dryRun
             await fireway.migrate(opts)
         } catch (e) {
             console.log('ERROR:', e.message);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const sade = require('sade');
+const admin = require('firebase-admin');
 const fireway = require('./index');
 const pkg = require('../package.json');
 
@@ -9,17 +10,18 @@ const prog = sade('fireway').version(pkg.version);
 prog
     .command('migrate')
     .option('--path', 'Path to migration files', './migrations')
-    .option('--projectId', 'Target firebase project')
-    .option('--dryrun', 'Simulates changes')
+    .option('--dryRun', 'Simulates changes')
     .describe('Migrates schema to the latest version')
     .example('migrate')
     .example('migrate --path=./my-migrations')
     .example('migrate --projectId=my-staging-id')
-    .example('migrate --dryrun')
+    .example('migrate --dryRun')
     .action(async (opts) => {
         try {
-            // TODO: provide app instance here in ops, dryRun
-            await fireway.migrate(opts)
+            // Requires env variable GOOGLE_APPLICATION_CREDENTIALS to be set
+            // See https://firebase.google.com/docs/admin/setup#initialize-without-parameters
+            const app = admin.initializeApp();
+            await fireway.migrate({ ...opts, debug: true, app });
         } catch (e) {
             console.log('ERROR:', e.message);
             process.exit(1);

--- a/src/files.js
+++ b/src/files.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const path = require('path');
+const util = require('util');
+const fs = require('fs');
+const md5 = require('md5');
+const semver = require('semver');
+
+const readFile = util.promisify(fs.readFile);
+const readdir = util.promisify(fs.readdir);
+const stat = util.promisify(fs.stat);
+const exists = util.promisify(fs.exists);
+
+const getFilesNewerThanVersion = (files, version) => files.filter(file => semver.gt(file.version, version));
+
+const resolveFiles = async (dir, log) => {
+    // Get all the scripts
+    if (!path.isAbsolute(dir)) {
+        dir = path.join(process.cwd(), dir);
+    }
+
+    if (!(await exists(dir))) {
+        throw new Error(`No directory at ${dir}`);
+    }
+
+    const filenames = [];
+    for (const file of await readdir(dir)) {
+        if (!(await stat(path.join(dir, file))).isDirectory()) {
+            filenames.push(file);
+        }
+    }
+
+    // Parse the version numbers from the script filenames
+    const versionToFile = new Map();
+    return filenames
+        .map(filename => {
+            // Skip files that start with a dot
+            if (filename[0] === '.') return;
+
+            const [filenameVersion, description] = filename.split('__');
+            const coerced = semver.coerce(filenameVersion);
+
+            if (!coerced) {
+                if (description) {
+                    // If there's a description, we assume you meant to use this file
+                    log(`WARNING: ${filename} doesn't have a valid semver version`);
+                }
+                return null;
+            }
+
+            // If there's a version, but no description, we have an issue
+            if (!description) {
+                throw new Error(`This filename doesn't match the required format: ${filename}`);
+            }
+
+            const { version } = coerced;
+
+            const existingFile = versionToFile.get(version);
+            if (existingFile) {
+                throw new Error(`Both ${filename} and ${existingFile} have the same version`);
+            }
+            versionToFile.set(version, filename);
+
+            return {
+                filename,
+                path: path.join(dir, filename),
+                version,
+                description: path.basename(description, '.js')
+            };
+        })
+        .filter(Boolean)
+        // sort files by semver
+        .sort((f1, f2) => semver.compare(f1.version, f2.version));
+}
+
+const calculateFileHash = async path => md5(await readFile(path));
+
+module.exports = {
+    getFilesNewerThanVersion,
+    resolveFiles,
+    calculateFileHash,
+}

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const admin = require('firebase-admin');
+
+// TODO: refactor this monster into something more convenient to read
+//  maybe something like this:
+// proxyFor(admin, 'firestore', ({ firestore }) => {
+//     return proxyFor(firestore, 'collection', ({ collection }) => {
+//         return proxyFor(collection, 'doc', ({ doc, operator: propertyKey }) => {
+//
+//         })
+//     })
+// }))
+const getLatestMigration = async collection => {
+    const result = await collection
+        .orderBy('installed_rank', 'desc')
+        .limit(1)
+        .get();
+    const [latestDoc] = result.docs;
+    const latest = latestDoc && latestDoc.data();
+
+    if (latest && !latest.success) {
+        throw new Error(`Migration to version ${ latest.version } using ${ latest.script } failed! Please restore backups and roll back database and code!`);
+    }
+    return latest;
+}
+
+const initFirebaseAdminProxy = (handler, dryRun = false) => new Proxy(admin, {
+    get(firebaseAdmin, service) {
+        if (service === 'firestore') {
+            // as admin.firestore is a function, we must return a function :)
+            return function (...args) {
+                return new Proxy(firebaseAdmin.firestore.apply(this, args), {
+                    get(firestore, fn) {
+                        if (fn === 'collection') {
+                            return function (...args) {
+                                return new Proxy(firestore.collection.apply(firestore, args), {
+                                    get(collection, fn) {
+                                        if (fn === 'doc') {
+                                            return function (...args) {
+                                                return new Proxy(collection.doc.apply(collection, args), {
+                                                    get(doc, operation) {
+                                                        return function (...args) {
+                                                            if (['create', 'set', 'update', 'delete'].includes(operation)) {
+                                                                if (!dryRun) {
+                                                                    handler({ operation, args, path: this.path })
+                                                                    return doc[operation].apply(doc, args)
+                                                                }
+                                                            }
+
+                                                            // TODO: fix promises here
+                                                            return doc[operation]
+                                                        }
+                                                    }
+                                                })
+                                            }
+                                        }
+                                        return collection[fn];
+                                    }
+                                })
+                            }
+                        } else if (fn === 'batch') {
+                            return function (...args) {
+                                return new Proxy(firestore.batch.apply(firestore, args), {
+                                    get(batch, fn) {
+                                        if (fn === 'commit') {
+                                            return function (...args) {
+                                                if (!dryRun) {
+                                                    handler({ operation, args, path: this.path })
+                                                    return batch.commit.apply(batch, args)
+                                                }
+                                            }
+                                        }
+                                        return batch[fn];
+                                    }
+                                })
+                            }
+                        }
+                        return firestore[fn];
+                    }
+                })
+            }
+        }
+        return firebaseAdmin[service];
+    }
+});
+
+module.exports = {
+    getLatestMigration,
+    initFirebaseAdminProxy
+}

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -2,15 +2,6 @@
 
 const admin = require('firebase-admin');
 
-// TODO: refactor this monster into something more convenient to read
-//  maybe something like this:
-// proxyFor(admin, 'firestore', ({ firestore }) => {
-//     return proxyFor(firestore, 'collection', ({ collection }) => {
-//         return proxyFor(collection, 'doc', ({ doc, operator: propertyKey }) => {
-//
-//         })
-//     })
-// }))
 const getLatestMigration = async collection => {
     const result = await collection
         .orderBy('installed_rank', 'desc')
@@ -25,36 +16,46 @@ const getLatestMigration = async collection => {
     return latest;
 }
 
-const initFirebaseAdminProxy = (handler, dryRun = false) => new Proxy(admin, {
+const initFirebaseAdminProxy = (onChangeHandler, dryRun = false) => new Proxy(admin, {
     get(firebaseAdmin, service) {
         if (service === 'firestore') {
-            // as admin.firestore is a function, we must return a function :)
-            return function (...args) {
+            // admin.firestore() is a function so we return a function here
+            return (...args) => {
                 return new Proxy(firebaseAdmin.firestore.apply(this, args), {
                     get(firestore, fn) {
                         if (fn === 'collection') {
-                            return function (...args) {
+                            // admin.firestore().collection() is a function so we return a function here
+                            return (...args) => {
                                 return new Proxy(firestore.collection.apply(firestore, args), {
                                     get(collection, fn) {
                                         if (fn === 'doc') {
-                                            return function (...args) {
+                                            // admin.firestore().collection().doc() is a function so we return a function here
+                                            return (...args) => {
                                                 return new Proxy(collection.doc.apply(collection, args), {
                                                     get(doc, operation) {
-                                                        return function (...args) {
-                                                            if (['create', 'set', 'update', 'delete'].includes(operation)) {
+                                                        // admin.firestore().collection().doc().[operation] is a function
+                                                        // so if it's one of following, we want to modify the behavior
+                                                        // so we return a new function
+                                                        if (['create', 'set', 'update', 'delete'].includes(operation)) {
+                                                            return (...args) => {
+                                                                onChangeHandler({
+                                                                    operation,
+                                                                    args,
+                                                                    path: doc.path,
+                                                                    dryRun
+                                                                })
                                                                 if (!dryRun) {
-                                                                    handler({ operation, args, path: this.path })
-                                                                    return doc[operation].apply(doc, args)
+                                                                    return doc[operation].apply(doc, args);
                                                                 }
                                                             }
-
-                                                            // TODO: fix promises here
-                                                            return doc[operation]
                                                         }
+                                                        // otherwise just return original implementation
+                                                        return doc[operation];
                                                     }
                                                 })
                                             }
                                         }
+                                        // if not a doc, return original implementation
                                         return collection[fn];
                                     }
                                 })
@@ -65,27 +66,47 @@ const initFirebaseAdminProxy = (handler, dryRun = false) => new Proxy(admin, {
                                     get(batch, fn) {
                                         if (fn === 'commit') {
                                             return function (...args) {
+                                                onChangeHandler({ operation: 'commit', args, path: this.path, dryRun })
                                                 if (!dryRun) {
-                                                    handler({ operation, args, path: this.path })
                                                     return batch.commit.apply(batch, args)
                                                 }
                                             }
                                         }
+                                        // if not a commit, return original implementation
                                         return batch[fn];
                                     }
                                 })
                             }
                         }
+                        // if not a collection, return original implementation
                         return firestore[fn];
                     }
                 })
             }
         }
+        // if not a firestore, return original implementation
         return firebaseAdmin[service];
     }
 });
 
+const saveMigration = async ({ file, installedRank, startedAt, executedBy, fileChecksum, executionTime, succeeded }, collection) => {
+    const id = `${ installedRank }-${ file.version }-${ file.description }`;
+    await collection.doc(id).set({
+        installed_rank: installedRank,
+        description: file.description,
+        version: file.version,
+        script: file.filename,
+        type: 'js',
+        checksum: fileChecksum,
+        installed_by: executedBy,
+        installed_on: startedAt,
+        execution_time: executionTime,
+        success: succeeded
+    });
+}
+
 module.exports = {
     getLatestMigration,
-    initFirebaseAdminProxy
+    initFirebaseAdminProxy,
+    saveMigration
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,122 +1,44 @@
 'use strict';
 
-const path = require('path');
-const util = require('util');
 const os = require('os');
-const fs = require('fs');
-const md5 = require('md5');
-const semver = require('semver');
 const firestoreService = require('./firestore');
+const filesService = require('./files');
 
-const readFile = util.promisify(fs.readFile);
-const readdir = util.promisify(fs.readdir);
-const stat = util.promisify(fs.stat);
-const exists = util.promisify(fs.exists);
-
-const getFilesNewerThanVersion = (files, version) => files.filter(file => semver.gt(file.version, version));
-
-const resolveFiles = async (dir, log) => {
-    // Get all the scripts
-    if (!path.isAbsolute(dir)) {
-        dir = path.join(process.cwd(), dir);
-    }
-
-    if (!(await exists(dir))) {
-        throw new Error(`No directory at ${dir}`);
-    }
-
-    const filenames = [];
-    for (const file of await readdir(dir)) {
-        if (!(await stat(path.join(dir, file))).isDirectory()) {
-            filenames.push(file);
-        }
-    }
-
-    // Parse the version numbers from the script filenames
-    const versionToFile = new Map();
-    return filenames
-        .map(filename => {
-            // Skip files that start with a dot
-            if (filename[0] === '.') return;
-
-            const [filenameVersion, description] = filename.split('__');
-            const coerced = semver.coerce(filenameVersion);
-
-            if (!coerced) {
-                if (description) {
-                    // If there's a description, we assume you meant to use this file
-                    log(`WARNING: ${filename} doesn't have a valid semver version`);
-                }
-                return null;
-            }
-
-            // If there's a version, but no description, we have an issue
-            if (!description) {
-                throw new Error(`This filename doesn't match the required format: ${filename}`);
-            }
-
-            const { version } = coerced;
-
-            const existingFile = versionToFile.get(version);
-            if (existingFile) {
-                throw new Error(`Both ${filename} and ${existingFile} have the same version`);
-            }
-            versionToFile.set(version, filename);
-
-            return {
-                filename,
-                path: path.join(dir, filename),
-                version,
-                description: path.basename(description, '.js')
-            };
-        })
-        .filter(Boolean)
-        // sort files by semver
-        .sort((f1, f2) => semver.compare(f1.version, f2.version));
-}
+const initStats = () => ({
+    scannedFilesCount: 0,
+    executedFilesCount: 0,
+    executedFiles: [],
+    create: 0,
+    set: 0,
+    update: 0,
+    delete: 0,
+    add: 0
+});
 
 async function migrate({ path: dir, dryRun, app, debug = false }) {
-    const log = (...args) => debug && console.log(...args)
-    const stats = {
-        scannedFilesCount: 0,
-        executedFilesCount: 0,
-        executedFiles: [],
-        create: 0,
-        set: 0,
-        update: 0,
-        delete: 0,
-        add: 0
-    };
+    const log = (...args) => debug && console.log(...args);
+    const stats = initStats();
 
     // Load migration files
-    let files = await resolveFiles(dir, log);
+    let files = await filesService.resolveFiles(dir, log);
     stats.scannedFilesCount = files.length;
     log(`Found ${stats.scannedFilesCount} migration files`);
 
     // Construct Firestore proxy so we can spy on method calls
     const firestore = firestoreService.initFirebaseAdminProxy(({ operation, args, path }) => {
-        log('Firestore change', { operation, args, path })
-        stats[operation] += 1
-    }).firestore(app);
+        log('Firestore change', { operation, args, path });
+        stats[operation] += 1;
+    }, dryRun).firestore(app);
 
     // Initialize migrations Firestore collection
     const collection = firestore.collection('fireway');
-
-    // TODO: this is not working properly, there is some issue with resolving .then() in proxy
-    // try {
-    //     await collection.add({ test: 'new ' })
-    // } catch (err) {
-    //     log('err', err)
-    // }
-    // log('here')
-    // process.exit(1)
 
     // Get the latest migration
     const latestMigration = await firestoreService.getLatestMigration(collection);
 
     let installedRank;
     if (latestMigration) {
-        files = getFilesNewerThanVersion(files, latestMigration.version);
+        files = filesService.getFilesNewerThanVersion(files, latestMigration.version);
         installedRank = latestMigration.installed_rank;
     } else {
         installedRank = -1;
@@ -124,7 +46,7 @@ async function migrate({ path: dir, dryRun, app, debug = false }) {
 
     log(`Executing ${files.length} migration files`);
 
-    // Execute them in order
+    // Execute migrations
     for (const file of files) {
         stats.executedFilesCount += 1;
         stats.executedFiles.push(file.filename);
@@ -146,21 +68,16 @@ async function migrate({ path: dir, dryRun, app, debug = false }) {
 
         // Upload the results
         log(`Uploading the results for ${file.filename}`);
-
         installedRank += 1;
-        const id = `${installedRank}-${file.version}-${file.description}`;
-        await collection.doc(id).set({
-            installed_rank: installedRank,
-            description: file.description,
-            version: file.version,
-            script: file.filename,
-            type: 'js',
-            checksum: md5(await readFile(file.path)),
-            installed_by: os.userInfo().username,
-            installed_on: startedAt,
-            execution_time: finishedAt - startedAt,
-            success: migrationSucceeded
-        });
+        await firestoreService.saveMigration({
+            file,
+            installedRank,
+            startedAt,
+            executionTime: finishedAt - startedAt,
+            succeeded: migrationSucceeded,
+            fileChecksum: await filesService.calculateFileHash(file.path),
+            executedBy: os.userInfo().username
+        }, collection);
 
         if (!migrationSucceeded) {
             throw err;
@@ -169,7 +86,7 @@ async function migrate({ path: dir, dryRun, app, debug = false }) {
 
     log('Finished all firestore migrations');
     log(`Files scanned:${stats.scannedFilesCount} executed:${stats.executedFilesCount}`);
-    log(`Docs added:${stats.add} created:${stats.create} updated:${stats.update} set:${stats.set - stats.executedFiles} deleted:${stats.delete}`);
+    log(`Docs added:${stats.add} created:${stats.create} updated:${stats.update} set:${stats.set - stats.executedFilesCount} deleted:${stats.delete}`);
 
     return stats;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,77 +1,21 @@
+'use strict';
+
 const path = require('path');
 const util = require('util');
 const os = require('os');
 const fs = require('fs');
 const md5 = require('md5');
-const admin = require('firebase-admin');
-const {Firestore, DocumentReference, CollectionReference, WriteBatch, FieldValue, FieldPath, Timestamp} = require('@google-cloud/firestore');
 const semver = require('semver');
+const firestoreService = require('./firestore');
 
 const readFile = util.promisify(fs.readFile);
 const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);
 const exists = util.promisify(fs.exists);
 
-// FIXME:
-//      if called multiple times, the output is logged multiple times
-//      if you try to proxy once, stats aren't updated on new instances
-function proxyWritableMethods(dryrun, stats) {
-    dryrun && console.log('Making firestore read-only');
+const getFilesNewerThanVersion = (files, version) => files.filter(file => semver.gt(file.version, version));
 
-    const ogCommit = WriteBatch.prototype._commit;
-    WriteBatch.prototype._commit = async function() {
-        if (dryrun) return [];
-        return ogCommit.apply(this, Array.from(arguments));
-    };
-
-    // Add logs for each item
-    const ogCreate = DocumentReference.prototype.create;
-    DocumentReference.prototype.create = function(doc) {
-        stats.created += 1;
-        console.log('Creating', JSON.stringify(doc));
-        return ogCreate.call(this, doc);
-    };
-
-    const ogSet = DocumentReference.prototype.set;
-    DocumentReference.prototype.set = function(doc, opts = {}) {
-        stats.set += 1;
-        console.log(opts.merge ? 'Merging' : 'Setting', this.path, JSON.stringify(doc));
-        return ogSet.call(this, doc, opts);
-    };
-
-    const ogUpdate = DocumentReference.prototype.update;
-    DocumentReference.prototype.update = function(doc) {
-        stats.updated += 1;
-        console.log('Updating', this.path, JSON.stringify(doc));
-        return ogUpdate.call(this, doc);
-    };
-
-    const ogDelete = DocumentReference.prototype.delete;
-    DocumentReference.prototype.delete = function() {
-        stats.deleted += 1;
-        console.log('Deleting', this.path);
-        return ogDelete.call(this);
-    };
-    
-    const ogAdd = CollectionReference.prototype.add;
-    CollectionReference.prototype.add = function(doc) {
-        stats.added += 1;
-        console.log('Adding', JSON.stringify(doc));
-        return ogAdd.call(this, doc);
-    };
-}
-
-async function migrate({path: dir, projectId, storageBucket, dryrun, app} = {}) {
-    const stats = {
-        scannedFiles: 0,
-        executedFiles: 0,
-        created: 0,
-        set: 0,
-        updated: 0,
-        deleted: 0,
-        added: 0
-    };
-
+const resolveFiles = async (dir, log) => {
     // Get all the scripts
     if (!path.isAbsolute(dir)) {
         dir = path.join(process.cwd(), dir);
@@ -90,149 +34,144 @@ async function migrate({path: dir, projectId, storageBucket, dryrun, app} = {}) 
 
     // Parse the version numbers from the script filenames
     const versionToFile = new Map();
-    let files = filenames.map(filename => {
-        // Skip files that start with a dot
-        if (filename[0] === '.') return;
-        
-        const [filenameVersion, description] = filename.split('__');
-        const coerced = semver.coerce(filenameVersion);
+    return filenames
+        .map(filename => {
+            // Skip files that start with a dot
+            if (filename[0] === '.') return;
 
-        if (!coerced) {
-            if (description) {
-                // If there's a description, we assume you meant to use this file
-                console.log(`WARNING: ${filename} doesn't have a valid semver version`);
+            const [filenameVersion, description] = filename.split('__');
+            const coerced = semver.coerce(filenameVersion);
+
+            if (!coerced) {
+                if (description) {
+                    // If there's a description, we assume you meant to use this file
+                    log(`WARNING: ${filename} doesn't have a valid semver version`);
+                }
+                return null;
             }
-            return null;
-        }
 
-        // If there's a version, but no description, we have an issue
-        if (!description) {
-            throw new Error(`This filename doesn't match the required format: ${filename}`);
-        }
+            // If there's a version, but no description, we have an issue
+            if (!description) {
+                throw new Error(`This filename doesn't match the required format: ${filename}`);
+            }
 
-        const {version} = coerced;
+            const { version } = coerced;
 
-        const existingFile = versionToFile.get(version);
-        if (existingFile) {
-            throw new Error(`Both ${filename} and ${existingFile} have the same version`);
-        }
-        versionToFile.set(version, filename);
+            const existingFile = versionToFile.get(version);
+            if (existingFile) {
+                throw new Error(`Both ${filename} and ${existingFile} have the same version`);
+            }
+            versionToFile.set(version, filename);
 
-        return {
-            filename,
-            path: path.join(dir, filename),
-            version,
-            description: path.basename(description, '.js')
-        };
-    }).filter(Boolean);
+            return {
+                filename,
+                path: path.join(dir, filename),
+                version,
+                description: path.basename(description, '.js')
+            };
+        })
+        .filter(Boolean)
+        // sort files by semver
+        .sort((f1, f2) => semver.compare(f1.version, f2.version));
+}
 
-    stats.scannedFiles = files.length;
-    console.log(`Found ${stats.scannedFiles} migration files`);
+async function migrate({ path: dir, dryRun, app, debug = false }) {
+    const log = (...args) => debug && console.log(...args)
+    const stats = {
+        scannedFilesCount: 0,
+        executedFilesCount: 0,
+        executedFiles: [],
+        create: 0,
+        set: 0,
+        update: 0,
+        delete: 0,
+        add: 0
+    };
 
-    // Find the files after the latest migration number
-    proxyWritableMethods(dryrun, stats);
+    // Load migration files
+    let files = await resolveFiles(dir, log);
+    stats.scannedFilesCount = files.length;
+    log(`Found ${stats.scannedFilesCount} migration files`);
 
-    if (!storageBucket && projectId) {
-        storageBucket = `${projectId}.appspot.com`;
-    }
-    
-    const providedApp = app;
-    if (!app) {
-        app = admin.initializeApp({
-            projectId,
-            storageBucket
-        });
-    }
+    // Construct Firestore proxy so we can spy on method calls
+    const firestore = firestoreService.initFirebaseAdminProxy(({ operation, args, path }) => {
+        log('Firestore change', { operation, args, path })
+        stats[operation] += 1
+    }).firestore(app);
 
-    // Use Firestore directly so we can mock for dryruns
-    const firestore = new Firestore({projectId});
-
+    // Initialize migrations Firestore collection
     const collection = firestore.collection('fireway');
 
+    // TODO: this is not working properly, there is some issue with resolving .then() in proxy
+    // try {
+    //     await collection.add({ test: 'new ' })
+    // } catch (err) {
+    //     log('err', err)
+    // }
+    // log('here')
+    // process.exit(1)
+
     // Get the latest migration
-    const result = await collection
-        .orderBy('installed_rank', 'desc')
-        .limit(1)
-        .get();
-    const [latestDoc] = result.docs;
-    const latest = latestDoc && latestDoc.data();
+    const latestMigration = await firestoreService.getLatestMigration(collection);
 
-    if (latest && !latest.success) {
-        throw new Error(`Migration to version ${latest.version} using ${latest.script} failed! Please restore backups and roll back database and code!`);
-    }
-
-    let installed_rank;
-    if (latest) {
-        files = files.filter(file => semver.gt(file.version, latest.version));
-        installed_rank = latest.installed_rank;
+    let installedRank;
+    if (latestMigration) {
+        files = getFilesNewerThanVersion(files, latestMigration.version);
+        installedRank = latestMigration.installed_rank;
     } else {
-        installed_rank = -1;
+        installedRank = -1;
     }
 
-    // Sort them by semver
-    files.sort((f1, f2) => semver.compare(f1.version, f2.version));
-
-    console.log(`Executing ${files.length} migration files`);
+    log(`Executing ${files.length} migration files`);
 
     // Execute them in order
     for (const file of files) {
-        stats.executedFiles += 1;
-        console.log('Running', file.filename);
-        
-        let migration;
-        try {
-            migration = require(file.path);
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+        stats.executedFilesCount += 1;
+        stats.executedFiles.push(file.filename);
+        log('Running', file.filename);
 
-        const start = new Date();
-        let success, finish;
+        let migrationSucceeded, startedAt, finishedAt, err;
         try {
-            await migration.migrate({app, firestore, FieldValue, FieldPath, Timestamp, dryrun});
-            success = true;
-        } catch(e) {
-            console.log(`Error in ${file.filename}`, e);
-            success = false;
+            const migration = require(file.path);
+            startedAt = new Date();
+            await migration.migrate({ app, firestore, dryRun });
+            migrationSucceeded = true;
+        } catch (e) {
+            log(`Error in ${file.filename}`, e);
+            migrationSucceeded = false;
+            err = e;
         } finally {
-            finish = new Date();
+            finishedAt = new Date();
         }
 
         // Upload the results
-        console.log(`Uploading the results for ${file.filename}`);
+        log(`Uploading the results for ${file.filename}`);
 
-        installed_rank += 1;
-        const id = `${installed_rank}-${file.version}-${file.description}`;
+        installedRank += 1;
+        const id = `${installedRank}-${file.version}-${file.description}`;
         await collection.doc(id).set({
-            installed_rank,
+            installed_rank: installedRank,
             description: file.description,
             version: file.version,
             script: file.filename,
             type: 'js',
             checksum: md5(await readFile(file.path)),
             installed_by: os.userInfo().username,
-            installed_on: start,
-            execution_time: finish - start,
-            success
+            installed_on: startedAt,
+            execution_time: finishedAt - startedAt,
+            success: migrationSucceeded
         });
 
-        if (!success) {
-            throw new Error('Stopped at first failure');
+        if (!migrationSucceeded) {
+            throw err;
         }
     }
 
-    // Ensure firebase terminates
-    if (!providedApp) {
-        app.delete();
-    }
-
-    const {scannedFiles, executedFiles, added, created, updated, set, deleted} = stats;
-    console.log('Finished all firestore migrations');
-    console.log(`Files scanned:${scannedFiles} executed:${executedFiles}`);
-    console.log(`Docs added:${added} created:${created} updated:${updated} set:${set - executedFiles} deleted:${deleted}`);
+    log('Finished all firestore migrations');
+    log(`Files scanned:${stats.scannedFilesCount} executed:${stats.executedFilesCount}`);
+    log(`Docs added:${stats.add} created:${stats.create} updated:${stats.update} set:${stats.set - stats.executedFiles} deleted:${stats.delete}`);
 
     return stats;
 }
 
-module.exports = {migrate};
+module.exports = { migrate };

--- a/src/index.js
+++ b/src/index.js
@@ -231,6 +231,8 @@ async function migrate({path: dir, projectId, storageBucket, dryrun, app} = {}) 
     console.log('Finished all firestore migrations');
     console.log(`Files scanned:${scannedFiles} executed:${executedFiles}`);
     console.log(`Docs added:${added} created:${created} updated:${updated} set:${set - executedFiles} deleted:${deleted}`);
+
+    return stats;
 }
 
 module.exports = {migrate};

--- a/tests/index.js
+++ b/tests/index.js
@@ -173,9 +173,9 @@ test('merge: error iterative', wrapper(async ({t, projectId, firestore, app}) =>
     }
 }));
 
-test('dryrun', wrapper(async ({t, projectId, firestore, app}) => {
+test('dryRun', wrapper(async ({t, projectId, firestore, app}) => {
     await fireway.migrate({
-        dryrun: true,
+        dryRun: true,
         projectId,
         path: __dirname + '/oneMigration',
         app
@@ -187,7 +187,7 @@ test('dryrun', wrapper(async ({t, projectId, firestore, app}) => {
     t.equal(dataSnapshot.size, 0);
 }));
 
-test('dryrun: delete', wrapper(async ({t, projectId, firestore, app}) => {
+test('dryRun: delete', wrapper(async ({t, projectId, firestore, app}) => {
     await fireway.migrate({
         projectId,
         path: __dirname + '/oneMigration',
@@ -200,7 +200,7 @@ test('dryrun: delete', wrapper(async ({t, projectId, firestore, app}) => {
     t.equal(dataSnapshot.size, 1);
 
     await fireway.migrate({
-        dryrun: true,
+        dryRun: true,
         projectId,
         path: __dirname + '/deleteMigration',
         app


### PR DESCRIPTION
This PR brings a lot of changes, also some breaking ones.

_Disclaimer_: I suppose you won't merge this as it changes a lot of stuff but maybe some things might be useful and integrated as small PRs 🤔 

-  **Avoid modifying firebase-admin** library, now it uses Javascript [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) instead. This **should also fix** the issue mentioned in the `FIXME` I believe
- Refactored `Firebase` initialization, as originally it created a new `app` but never really used it (as it was using `new Firestore` directly from `@google-cloud/firestore` which is initialized via an environment variable). Now it doesn't initialize anything on its own. It rather accepts a firebase app instance or uses `admin.initializeApp()` with reading credentials from `GOOGLE_APPLICATION_CREDENTIALS` (when used via CLI)
- Logging is now configurable (disabled by default) so it can be better integrated with other code
- Refactored code into several files and smaller functions to make the overall structure easier to read