### PR TITLE
Warn or wait for open async calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options
   --path         Path to migration files  (default ./migrations)
   --projectId    Target firebase project
   --dryrun       Simulates changes
+  --forceWait    Forces waiting for migrations that do not strictly manage async calls
   --require      Requires a module before executing
   -h, --help     Displays this message
 
@@ -53,6 +54,7 @@ Examples
   $ fireway migrate --path=./my-migrations
   $ fireway migrate --projectId=my-staging-id
   $ fireway migrate --dryrun
+  $ fireway migrate --forceWait
   $ fireway --require="ts-node/register" migrate
 ```
 
@@ -83,9 +85,7 @@ For type checking and Intellisense, there are two options:
     import { MigrateOptions } from 'fireway';
 
     export async function migrate({firestore} : MigrateOptions) {
-        await firestore
-          .collection('data').doc('one')
-          .set({key: 'value'});
+        await firestore.collection('data').doc('one').set({key: 'value'});
     };
    ```
 3. Run `fireway migrate` with the `require` option

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ prog
     .option('--path', 'Path to migration files', './migrations')
     .option('--projectId', 'Target firebase project')
     .option('--dryrun', 'Simulates changes')
-    .option('--forceWait', 'Forces waiting for migrations that do not strictly manage Promises')
+    .option('--forceWait', 'Forces waiting for migrations that do not strictly manage async calls')
     .describe('Migrates schema to the latest version')
     .example('migrate')
     .example('migrate --path=./my-migrations')

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,11 +15,13 @@ prog
     .option('--path', 'Path to migration files', './migrations')
     .option('--projectId', 'Target firebase project')
     .option('--dryrun', 'Simulates changes')
+    .option('--forceWait', 'Forces waiting for migrations that do not strictly manage Promises')
     .describe('Migrates schema to the latest version')
     .example('migrate')
     .example('migrate --path=./my-migrations')
     .example('migrate --projectId=my-staging-id')
     .example('migrate --dryrun')
+    .example('migrate --forceWait')
     .example('--require="ts-node/register" migrate')
     .action(async (opts) => {
         try {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const {EventEmitter} = require('events');
 const util = require('util');
 const os = require('os');
 const fs = require('fs');
@@ -95,9 +96,17 @@ function proxyWritableMethods() {
 	});
 }
 
-async function trackAsync(filePath, fn) {
+async function trackAsync({log, file, forceWait}, fn) {
 	// Track filenames for async handles
 	const activeHandles = new Map();
+	const emitter = new EventEmitter();
+	function deleteHandle(id) {
+		activeHandles.delete(id);
+		emitter.emit('deleted', id);
+	}
+	function waitForDeleted() {
+		return new Promise(r => emitter.once('deleted', () => r()));
+	}
 	const hook = asyncHooks.createHook({
 		init(asyncId) {
 			for (const call of callsites()) {
@@ -109,7 +118,7 @@ async function trackAsync(filePath, fn) {
 					name.startsWith('timers.js')
 				) continue;
 
-				if (name === filePath) {
+				if (name === file.path) {
 					const filename = call.getFileName();
 					const lineNumber = call.getLineNumber();
 					const columnNumber = call.getColumnNumber();
@@ -118,24 +127,51 @@ async function trackAsync(filePath, fn) {
 				}
 			}
 		},
-		before: asyncId => activeHandles.delete(asyncId),
-		promiseResolve: asyncId => activeHandles.delete(asyncId)
+		before: deleteHandle,
+		after: deleteHandle,
+		promiseResolve: deleteHandle
 	}).enable();
+
+	async function handleCheck() {
+		while (activeHandles.size) {
+			if (forceWait) {
+				// TODO: Wait for the next handle to be deleted or race a timeout
+				await waitForDeleted();
+			} else {
+				console.warn(
+					'WARNING: fireway detected unresolved async handles',
+					Array.from(activeHandles.values())
+				);
+				break;
+			}
+		}
+	}
+
+	let rejection;
+	const unhandled = reason => rejection = reason;
+	process.once('unhandledRejection', unhandled);
+	process.once('uncaughtException', unhandled);
 	
 	try {
-		return await fn();
-	} finally {
-		if (activeHandles.size) {
-			console.warn(
-				'WARNING: fireway detected unresolved async handles',
-				Array.from(activeHandles.values())
-			);
+		const res = await fn();
+		await handleCheck();
+
+		// Wait a tick or so for the unhandledRejection
+		await new Promise(r => setTimeout(() => r(), 1));
+
+		process.removeAllListeners('unhandledRejection');
+		process.removeAllListeners('uncaughtException');
+		if (rejection) {
+			log(`Error in ${file.filename}`, rejection);
+			return false;
 		}
+		return res;
+	} finally {
 		hook.disable();
 	}
 }
 
-async function migrate({path: dir, projectId, storageBucket, dryrun, app, debug = false, require: req} = {}) {
+async function migrate({path: dir, projectId, storageBucket, dryrun, app, debug = false, require: req, forceWait = false} = {}) {
 	if (req) {
 		try {
 			require(req);
@@ -277,15 +313,15 @@ async function migrate({path: dir, projectId, storageBucket, dryrun, app, debug 
 			throw e;
 		}
 
-		let start, success, finish;
-		await trackAsync(file.path, async () => {
+		let start, finish;
+		const success = await trackAsync({log, file, forceWait}, async () => {
 			start = new Date();
 			try {
 				await migration.migrate({app, firestore, FieldValue, FieldPath, Timestamp, dryrun});
-				success = true;
+				return true;
 			} catch(e) {
 				log(`Error in ${file.filename}`, e);
-				success = false;
+				return false;
 			} finally {
 				finish = new Date();
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,11 @@ async function trackAsync({log, file, forceWait}, fn) {
 	async function handleCheck() {
 		while (activeHandles.size) {
 			if (forceWait) {
-				// TODO: Wait for the next handle to be deleted or race a timeout
+				// NOTE: Attempting to add a timeout requires
+				// shutting down the entire process cleanly.
+				// If someone decides not to return proper
+				// Promises, and provides --forceWait, long
+				// waits are expected.
 				await waitForDeleted();
 			} else {
 				console.warn(
@@ -174,6 +178,9 @@ async function trackAsync({log, file, forceWait}, fn) {
 			return false;
 		}
 		return res;
+	} catch(e) {
+		log(e);
+		return false;
 	} finally {
 		hook.disable();
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ async function trackAsync({log, file, forceWait}, fn) {
 		promiseResolve: deleteHandle
 	}).enable();
 
+	let logged;
 	async function handleCheck() {
 		while (activeHandles.size) {
 			if (forceWait) {
@@ -148,10 +149,14 @@ async function trackAsync({log, file, forceWait}, fn) {
 				// If someone decides not to return proper
 				// Promises, and provides --forceWait, long
 				// waits are expected.
+				if (!logged) {
+					log('Waiting for async calls to resolve');
+					logged = true;
+				}
 				await waitForDeleted();
 			} else {
 				console.warn(
-					'WARNING: fireway detected unresolved async handles',
+					'WARNING: fireway detected open async calls. Use --forceWait if you want to wait:',
 					Array.from(activeHandles.values())
 				);
 				break;

--- a/tests/index.js
+++ b/tests/index.js
@@ -311,7 +311,7 @@ test('async: unhandled async warning', wrapper(async ({t, projectId, app}) => {
 	});
 
 	t.equal(
-		terminal.includes('WARNING: fireway detected unresolved async handles'),
+		terminal.includes('WARNING: fireway detected open async calls'),
 		true
 	);
 }));
@@ -325,7 +325,7 @@ test('async: handle unhandled async', wrapper(async ({t, projectId, app}) => {
 	});
 
 	t.equal(
-		terminal.includes('WARNING: fireway detected unresolved async handles'),
+		terminal.includes('WARNING: fireway detected open async calls'),
 		false
 	);
 }));
@@ -407,7 +407,7 @@ test('TypeScript: unhandled async warning', wrapper(async ({t, projectId, app}) 
 	});
 
 	t.equal(
-		terminal.includes('WARNING: fireway detected unresolved async handles'),
+		terminal.includes('WARNING: fireway detected open async calls'),
 		true
 	);
 }));
@@ -421,7 +421,7 @@ test('TypeScript: handle unhandled async', wrapper(async ({t, projectId, app}) =
 	});
 
 	t.equal(
-		terminal.includes('WARNING: fireway detected unresolved async handles'),
+		terminal.includes('WARNING: fireway detected open async calls'),
 		false
 	);
 }));

--- a/tests/index.js
+++ b/tests/index.js
@@ -330,8 +330,7 @@ test('async: handle unhandled async', wrapper(async ({t, projectId, app}) => {
 	);
 }));
 
-// FIXME: hangs if after another forceWait test
-test.skip('async: handle unhandled async error', wrapper(async ({t, projectId, firestore, app}) => {
+test('async: handle unhandled async error', wrapper(async ({t, projectId, firestore, app}) => {
 	try {
 		await fireway.migrate({
 			projectId,
@@ -413,14 +412,12 @@ test('TypeScript: unhandled async warning', wrapper(async ({t, projectId, app}) 
 	);
 }));
 
-// FIXME: this always hangs
-test.skip('TypeScript: handle unhandled async', wrapper(async ({t, projectId, app}) => {
+test('TypeScript: handle unhandled async', wrapper(async ({t, projectId, app}) => {
 	await fireway.migrate({
 		projectId,
 		path: __dirname + '/tsOpenTimeoutMigration',
 		app,
-		forceWait: true,
-		require: 'ts-node/register'
+		forceWait: true
 	});
 
 	t.equal(
@@ -428,4 +425,33 @@ test.skip('TypeScript: handle unhandled async', wrapper(async ({t, projectId, ap
 		false
 	);
 }));
-test.skip('TypeScript: unhandled async error');
+
+test('TypeScript: handle unhandled async error', wrapper(async ({t, projectId, firestore, app}) => {
+	try {
+		await fireway.migrate({
+			projectId,
+			path: __dirname + '/tsOpenTimeoutFailureMigration',
+			app,
+			forceWait: true
+		});
+		t.fail('Should throw an error');
+	} catch (e) {
+		const snapshot = await firestore.collection('fireway').get();
+		t.equal(snapshot.size, 1);
+		await assertData(t, firestore, 'fireway/0-0.0.0-error', {
+			checksum: 'e26a1eaed0c4f9549f6902001139cfb4',
+			description: 'error',
+			execution_time: 251,
+			installed_by: 'len',
+			installed_on: {
+				seconds: 1564681117,
+				nanoseconds: 401000000
+			},
+			installed_rank: 0,
+			script: 'v0__error.ts',
+			success: false,
+			type: 'ts',
+			version: '0.0.0'
+		});
+	}
+}));

--- a/tests/openTimeoutFailureMigration/v0__error.js
+++ b/tests/openTimeoutFailureMigration/v0__error.js
@@ -1,0 +1,5 @@
+module.exports.migrate = () => {
+    (async () => {
+        throw new Error('Some error');
+    })();
+};

--- a/tests/tsOpenTimeoutFailureMigration/v0__error.ts
+++ b/tests/tsOpenTimeoutFailureMigration/v0__error.ts
@@ -1,0 +1,5 @@
+export async function migrate() {
+    (async () => {
+        throw new Error('Some error');
+    })();
+};


### PR DESCRIPTION
This adds a warning when async calls remain open after running a migration. It also provides a `--forceWait` option to automatically wait for these calls to resolve.

This should resolve #13 