### PR TITLE
Log field updates for txn.update(ref, path, data)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,9 +79,13 @@ function proxyWritableMethods() {
 		log(opts.merge ? 'Merging' : 'Setting', ref.path, JSON.stringify(doc));
 	});
 
-	mitm(WriteBatch.prototype, 'update', ([ref, doc], stats, log) => {
+	mitm(WriteBatch.prototype, 'update', ([ref, doc, update = undefined], stats, log) => {
 		stats.updated += 1;
-		log('Updating', ref.path, JSON.stringify(doc));
+		if (update) {
+			log('Updating', ref.path, JSON.stringify(doc), update);
+		} else {
+			log('Updating', ref.path, JSON.stringify(doc));
+		}
 	});
 
 	mitm(WriteBatch.prototype, 'delete', ([ref], stats, log) => {


### PR DESCRIPTION
Logs for the `update` operation currently don't include the data that's being updated when using the alternative form `txn.update(ref, path, data)`.

For example, `txn.update('some/db/path/doc123', "restriction.period.end", '2021-02-21')` yields the following line from  the logs:

```
Updating some/db/path/doc123 "restriction.period.end"
```