### PR TITLE
feat: support dotenv vars to set up credentials and projectId

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GOOGLE_PROJECT_ID=
+GOOGLE_APPLICATION_CREDENTIALS=./google-service-account.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ yarn global add fireway
 npx fireway
 ```
 
+## Credentials
+
+In order to fireway be able to connect to firestore you need to set up the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with service account file path.
+
+Example:
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/firestore-service-account.json"
+```
+
 ## CLI
 
 ```bash
@@ -31,15 +40,6 @@ Options
 Examples
   $ fireway migrate
   $ fireway --require="ts-node/register" migrate
-```
-
-## Credentials
-
-In order to fireway be able to connect to firestore you need to set up the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with service account file path.
-
-Example:
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS="path/to/firestore-service-account.json"
 ```
 
 ### `fireway migrate`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,19 @@ In order to fireway be able to connect to firestore you need to set up the envir
 
 Example:
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS="path/to/firestore-service-account.json"
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/google-service-account.json"
 ```
+
+### .env support
+
+Alternatively, you can set upt `GOOGLE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` vars on `.env` file.
+
+Example:
+```.env
+GOOGLE_PROJECT_ID=project-id
+GOOGLE_APPLICATION_CREDENTIALS="path/to/google-service-account.json"
+```
+
 
 ## CLI
 
@@ -66,6 +77,7 @@ Examples
   $ fireway migrate --forceWait
   $ fireway --require="ts-node/register" migrate
 ```
+PS: Alternatively to `--projectId` you can set up a `GOOGLE_PROJECT_ID` var on `.env` file.
 
 ## Migration file format
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Examples
   $ fireway --require="ts-node/register" migrate
 ```
 
+## Credentials
+
+In order to fireway be able to connect to firestore you need to set up the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with service account file path.
+
+Example:
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="path/to/firestore-service-account.json"
+```
+
 ### `fireway migrate`
 ```bash
 Description

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@google-cloud/firestore": "^5.0.2",
     "callsites": "^3.1.0",
+    "dotenv": "^16.0.3",
     "firebase-admin": "^10.1.0",
     "md5": "^2.2.1",
     "sade": "^1.6.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require("dotenv").config();
 const sade = require('sade');
 const fireway = require('./index');
 const pkg = require('../package.json');

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,7 @@ async function trackAsync({log, file, forceWait}, fn) {
 }
 trackAsync[dontTrack] = true;
 
-async function migrate({path: dir, projectId, storageBucket, dryrun, app, debug = false, require: req, forceWait = false} = {}) {
+async function migrate({path: dir, projectId = process.env.GOOGLE_PROJECT_ID, storageBucket, dryrun, app, debug = false, require: req, forceWait = false} = {}) {
 	if (req) {
 		try {
 			require(req);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,6 +2006,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
@@ -4202,14 +4207,7 @@ node-emoji@^1.4.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@2.6.7, node-fetch@^2.6.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
Hi, 

first of all, thanks for this amazing project. It's helping me a lot.

I opened this PR to add support to .env vars using dotenv lib. I think it's very useful, especially, in the development environment. 

Dotenv is a well-known lib to storing environment variables. Supporting .env vars file on fireway we don't need to manually export credentials var or pass projectId option on cli, we can set fireway vars on the same file(.env) we are used to using, and it makes cli migrate command less verbose.

The vars that this feature uses are:

```
GOOGLE_PROJECT_ID=project-id
GOOGLE_APPLICATION_CREDENTIALS=path/to/googe-service-account.json
```
Doing so we can run `fireway migrate` command without `--projectId` option and we don't need to run `export GOOGLE_APPLICATION_CREDENTIALS="path/to/googe-service-account.json"` on the terminal.

I hope this helps other devs as helped me.